### PR TITLE
[W-38][W-39] Visual indication for successful calls

### DIFF
--- a/apps/cli/cli-core/src/trpc.ts
+++ b/apps/cli/cli-core/src/trpc.ts
@@ -119,7 +119,7 @@ export const cliApiRouter = t.router({
           headers: config.headers,
           body:
             config.method !== "GET" ? JSON.stringify(parsedJson) : undefined,
-        });
+        }).then((res) => res.json());
 
         console.log(
           `[INFO] Got response: \n\n${JSON.stringify(fetchedResult, null, 2)}\n`

--- a/apps/cli/cli-web/src/components/jsonblobs.tsx
+++ b/apps/cli/cli-web/src/components/jsonblobs.tsx
@@ -27,6 +27,9 @@ export const JsonBlobs = () => {
   const { data, refetch: refetchBlobs } = cliApi.getBlobs.useQuery();
 
   const { mutate: runFile } = cliApi.runFile.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Got response from server! Check console for details.`);
+    },
     onError: (err) => {
       toast.error(err.message);
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11494384/217947796-09b337c2-21a6-4f8f-b05c-0fc7c94d529e.png)


Also fixes the incorrect `{ "size":0 }` shown in console:

![image](https://user-images.githubusercontent.com/11494384/217947891-4416de46-85b3-4afb-95d8-4b64815869bc.png)
